### PR TITLE
Adapt version string

### DIFF
--- a/bin/xmlformat.pl
+++ b/bin/xmlformat.pl
@@ -74,7 +74,7 @@ $Getopt::Long::ignorecase = 0; # options are case sensitive
 $Getopt::Long::bundling = 1;   # allow short options to be bundled
 
 my $PROG_NAME = "xmlformat";
-my $PROG_VERSION = "1.04";
+my $PROG_VERSION = "1.9";
 my $PROG_LANG = "Perl";
 
 # ----------------------------------------------------------------------
@@ -1660,7 +1660,8 @@ if (defined ($help))
 
 if (defined ($show_version))
 {
-  print "$PROG_NAME $PROG_VERSION ($PROG_LANG version)\n";
+  print "$PROG_NAME $PROG_VERSION $PROG_LANG version\n";
+  print "(based on Kitebird's xmlformat implementation v1.04)\n";
   exit (0);
 }
 

--- a/bin/xmlformat.rb
+++ b/bin/xmlformat.rb
@@ -21,7 +21,7 @@
 require "getoptlong"
 
 PROG_NAME = "xmlformat"
-PROG_VERSION = "1.04"
+PROG_VERSION = "1.9"
 PROG_LANG = "Ruby"
 
 # ----------------------------------------------------------------------
@@ -1474,7 +1474,8 @@ if help
 end
 
 if show_version
-  puts "#{PROG_NAME} #{PROG_VERSION} (#{PROG_LANG} version)"
+  puts "#{PROG_NAME} #{PROG_VERSION} #{PROG_LANG} version"
+  puts "(based on Kitebird's xmlformat implementation v1.04)"
   exit(0)
 end
 


### PR DESCRIPTION
This fixes #8.

Refer to Kitbird's original implementation in version 1.04

@someth2say I wasn't sure which version I should use. I thought it would be useful to have version 1.9 which is higher than the original implementation (but lower for your 2.0). :wink: 

The current string looks like this:

```
$ ./bin/xmlformat.pl --version
xmlformat 1.9 Perl version
(based on Kitebird's xmlformat implementation v1.04)
```

Let me know what you prefer and I will change that. When you are happy with that change, could you make a release, please?

Thanks!